### PR TITLE
Using alternate appdmg_eula provider - performs chown

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,6 +4,6 @@
 class kindle {
   package { 'Kindle':
     source    => 'http://kindleformac.amazon.com/40381/KindleForMac.dmg',
-    provider  => 'appdmg'
+    provider  => 'appdmg_eula'
   }
 }


### PR DESCRIPTION
The puppet provided appdmg package provider doesn't do anything with file ownership/permissions.  When a package is installed on OSX for an individual user, the package will function properly, but the user will not be able to update via normal routes (e.g. AppStore).  By contrast, the boxen provided appdmg_eula provider does a recursive chown on the new app, more closely mimicking the behavior of the user installing the app manually.
