### PR TITLE
Update to latest version

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,7 +3,7 @@
 # include kindle
 class kindle {
   package { 'Kindle':
-    source    => 'http://kindleformac.amazon.com/40381/KindleForMac.dmg',
+    source    => 'http://kindleformac.amazon.com/40499/KindleForMac.dmg',
     provider  => 'appdmg'
   }
 }

--- a/spec/classes/kindle_spec.rb
+++ b/spec/classes/kindle_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'kindle' do
   it do
     should contain_package('Kindle').with({
-      :source   => 'http://kindleformac.amazon.com/40381/KindleForMac.dmg', 
+      :source   => 'http://kindleformac.amazon.com/40499/KindleForMac.dmg',
       :provider => 'appdmg'
     })
   end

--- a/spec/fixtures/modules/kindle/manifests/init.pp
+++ b/spec/fixtures/modules/kindle/manifests/init.pp
@@ -3,7 +3,7 @@
 # include kindle
 class kindle {
   package { 'Kindle':
-    source    => 'http://kindleformac.amazon.com/40381/KindleForMac.dmg',
+    source    => 'http://kindleformac.amazon.com/40499/KindleForMac.dmg',
     provider  => 'appdmg'
   }
 }


### PR DESCRIPTION
Fixes crash in OS X 10.9.5. https://github.com/boxen/puppet-kindle/issues/8.
